### PR TITLE
ci: standardize runs-on to ebpro-org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
   build-docker:
     name: Build & smoke-test images (self-hosted, matrix)
     needs: validate
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ebpro-org
     if: >
       github.event_name == 'push'
       || (github.event_name == 'pull_request'
@@ -96,7 +96,7 @@ jobs:
 
   publish:
     name: Publish images (tags only)
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ebpro-org
     needs: build-docker
     if: startsWith(github.ref, 'refs/tags/')
 


### PR DESCRIPTION
Converts selected self-hosted, empty, and legacy `arc-runner-set-compute-lsis` runner selections to `runs-on: ebpro-org`.

Changes:
- `.github/workflows/ci.yml` line 47: `    runs-on: [self-hosted, Linux, X64]` -> `    runs-on: ebpro-org`
- `.github/workflows/ci.yml` line 99: `    runs-on: [self-hosted, Linux, X64]` -> `    runs-on: ebpro-org`